### PR TITLE
fix: hide useLayoutEffect warning when using SSR

### DIFF
--- a/src/utils/useSafeDispatch.ts
+++ b/src/utils/useSafeDispatch.ts
@@ -1,9 +1,15 @@
 import * as React from "react";
 
+// Hide `useLayoutEffect` warning with SSR
+// See: https://medium.com/@alexandereardon/uselayouteffect-and-ssr-192986cdcf7a
+const useIsomorphicLayoutEffect = typeof window !== 'undefined'
+  ? React.useLayoutEffect
+  : React.useEffect;
+
 export function useSafeDispatch<T>(dispatch: React.Dispatch<T>) {
   const mountedRef = React.useRef(false);
 
-  React.useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     mountedRef.current = true;
     return () => {
       mountedRef.current = false;

--- a/src/utils/useSafeDispatch.ts
+++ b/src/utils/useSafeDispatch.ts
@@ -2,9 +2,8 @@ import * as React from "react";
 
 // Hide `useLayoutEffect` warning with SSR
 // See: https://medium.com/@alexandereardon/uselayouteffect-and-ssr-192986cdcf7a
-const useIsomorphicLayoutEffect = typeof window !== 'undefined'
-  ? React.useLayoutEffect
-  : React.useEffect;
+const useIsomorphicLayoutEffect =
+  typeof window !== "undefined" ? React.useLayoutEffect : React.useEffect;
 
 export function useSafeDispatch<T>(dispatch: React.Dispatch<T>) {
   const mountedRef = React.useRef(false);


### PR DESCRIPTION
When using SSR and invoked `useLayoutEffect` inside the component, a warning
 is prompted.


> Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer's output format. This will lead to a mismatch between the initial, non-hydrated UI and the intended UI. To avoid this, useLayoutEffect should only be used in components that render exclusively on the client. See https://reactjs.org/link/uselayouteffect-ssr for common fixes.


I followed the [hack](https://medium.com/@alexandereardon/uselayouteffect-and-ssr-192986cdcf7a) proposed by @alexandereardon to resolve the issue.