### PR TITLE
fix: use polling on accounts to handle pending connection request

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,3 +1,3 @@
 {
-  "branches": ["main"]
+  "branches": ["main", "next"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "eslint-plugin-react": "^7.22.0",
         "eslint-plugin-react-hooks": "^4.2.0",
         "eslint-plugin-testing-library": "^3.10.1",
-        "eth-testing": "^1.0.0-alpha.1",
+        "eth-testing": "^1.1.0-alpha.4",
         "husky": "^4.3.7",
         "jest": "^26.6.3",
         "lint-staged": "^10.5.3",
@@ -5179,9 +5179,9 @@
       }
     },
     "node_modules/eth-testing": {
-      "version": "1.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/eth-testing/-/eth-testing-1.0.0-alpha.1.tgz",
-      "integrity": "sha512-vUTQzyzWxAUn3R0RlMipC3QHdD9WYXVKFFpX9YG2frEl7nIgEGh1lnNqrTALB0ANXWA9OIzrXEjVBkGRBpXKhg==",
+      "version": "1.1.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/eth-testing/-/eth-testing-1.1.0-alpha.4.tgz",
+      "integrity": "sha512-rOIVsizQb+T7RPn85IkCR60U+6sJGyixw14WBYZKeRFVtmV9s9hQDRgV0KnKFp0H529InKDGtlkPoL5bFui+WA==",
       "dev": true,
       "dependencies": {
         "@ethersproject/abi": "^5.4.0",
@@ -20841,9 +20841,9 @@
       "dev": true
     },
     "eth-testing": {
-      "version": "1.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/eth-testing/-/eth-testing-1.0.0-alpha.1.tgz",
-      "integrity": "sha512-vUTQzyzWxAUn3R0RlMipC3QHdD9WYXVKFFpX9YG2frEl7nIgEGh1lnNqrTALB0ANXWA9OIzrXEjVBkGRBpXKhg==",
+      "version": "1.1.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/eth-testing/-/eth-testing-1.1.0-alpha.4.tgz",
+      "integrity": "sha512-rOIVsizQb+T7RPn85IkCR60U+6sJGyixw14WBYZKeRFVtmV9s9hQDRgV0KnKFp0H529InKDGtlkPoL5bFui+WA==",
       "dev": true,
       "requires": {
         "@ethersproject/abi": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -1,3 +1,4 @@
+
 {
   "name": "metamask-react",
   "version": "0.0.1-semantic-release",
@@ -57,7 +58,7 @@
     "eslint-plugin-react": "^7.22.0",
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-testing-library": "^3.10.1",
-    "eth-testing": "^1.0.0-alpha.1",
+    "eth-testing": "^1.1.0-alpha.4",
     "husky": "^4.3.7",
     "jest": "^26.6.3",
     "lint-staged": "^10.5.3",

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -119,12 +119,9 @@ describe("MetaMask provider", () => {
           shouldThrow: true,
         });
 
-        const { result, waitForNextUpdate, waitForValueToChange } = renderHook(
-          useMetaMask,
-          {
-            wrapper: MetaMaskProvider,
-          }
-        );
+        const { result, waitForNextUpdate } = renderHook(useMetaMask, {
+          wrapper: MetaMaskProvider,
+        });
 
         expect(result.current.status).toEqual("initializing");
 
@@ -142,7 +139,7 @@ describe("MetaMask provider", () => {
           testingUtils.mockAccounts([address]);
         });
 
-        await waitForValueToChange(() => result.current.status);
+        await waitForNextUpdate();
 
         expect(result.current.status).toEqual("connected");
         expect(result.current.account).toEqual(address);


### PR DESCRIPTION
## Summary

A polling mechanism on `eth_accounts` endpoint has been added when connecting.

Additionally, the particular case of pending request error does not trigger the bubble up of the error while connecting.

Based from the work of @guillermodlpa https://github.com/guillermodlpa/metamask-react/commit/46a614661290c725eeb7c0c5060f3932a7a7d30c.

Resolves #13

