### PR TITLE
feat: improve state typing, expose useConnectedMetaMask

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,22 @@ Simplistic Context provider and consumer hook in order to manage MetaMask in the
 
 ## Installation
 
-The recommend way to use MetaMask React with a React app is to install it as a dependency:
-```shell
-# If you use npm:
-npm install metamask-react
+The recommend way to use MetaMask React with a React app is to install it as a dependency.
 
-# Or if you use Yarn:
+If you use `npm`:
+```console
+npm install metamask-react
+```
+
+Or if you use `yarn`:
+```console
 yarn add metamask-react
 ```
 
-## Example
+## Quick Start
 
 The first step is to wrap you `App` or any React subtree with the `MetaMaskProvider`
-```javascript
+```TypeScript
 // index.js
 import { MetaMaskProvider } from "metamask-react";
 
@@ -33,14 +36,14 @@ ReactDOM.render(
 ```
 
 In any React child of the provider, one can use the `useMetaMask` hook in order to access the state and methods.
-```javascript
+```TypeScript
 // app.js
 import { useMetaMask } from "metamask-react";
 
 ...
 
 function App() {
-    const { status, connect, account } = useMetaMask();
+    const { status, connect, account, chainId, ethereum } = useMetaMask();
 
     if (status === "initializing") return <div>Synchronisation with MetaMask ongoing...</div>
 
@@ -50,7 +53,7 @@ function App() {
 
     if (status === "connecting") return <div>Connecting...</div>
 
-    if (status === "connected") return <div>Connected account: {account}</div>
+    if (status === "connected") return <div>Connected account {account} on chain ID ${chainId}</div>
 
     return null;
 }
@@ -73,3 +76,6 @@ Here is an abstract on the different statuses:
 - `connected`: MetaMask is connected to the application
 - `connecting`: the connection of your accounts to the application is ongoing
 
+## Type safe hook
+
+Most of the time, the application will use the state when the user is connected, i.e. with status `connected`. Therefore the hook `useConnectedMetaMask` is additionally exposed, it is the same hook as `useMetaMask` but is typed with the connected state, e.g. the `account` or the `chainId` are necessarily not `null`. This hook is only usable when the status is equal to `connected`, it will throw otherwise.

--- a/src/__tests__/reducer.test.ts
+++ b/src/__tests__/reducer.test.ts
@@ -1,0 +1,85 @@
+import { MetaMaskState } from "../metamask-context";
+import { reducer } from "../reducer";
+
+describe("state reducer, edge cases", () => {
+  test('transition from "initializing" to "connecting" is not allowed', () => {
+    jest.spyOn(console, "warn").mockImplementationOnce(() => {});
+    const initialState: MetaMaskState = {
+      account: null,
+      chainId: null,
+      status: "initializing",
+    };
+    const state = reducer(initialState, { type: "metaMaskConnecting" });
+    expect(initialState).toEqual(state);
+  });
+  test('transition from "unavailable" to "connecting" is not allowed', () => {
+    jest.spyOn(console, "warn").mockImplementationOnce(() => {});
+    const initialState: MetaMaskState = {
+      account: null,
+      chainId: null,
+      status: "unavailable",
+    };
+    const state = reducer(initialState, { type: "metaMaskConnecting" });
+    expect(initialState).toEqual(state);
+  });
+
+  test('transition from "initializing" to "notConnected" is not allowed', () => {
+    jest.spyOn(console, "warn").mockImplementationOnce(() => {});
+    const initialState: MetaMaskState = {
+      account: null,
+      chainId: null,
+      status: "initializing",
+    };
+    const state = reducer(initialState, { type: "metaMaskPermissionRejected" });
+    expect(initialState).toEqual(state);
+  });
+  test('transition from "unavailable" to "notConnected" is not allowed', () => {
+    jest.spyOn(console, "warn").mockImplementationOnce(() => {});
+    const initialState: MetaMaskState = {
+      account: null,
+      chainId: null,
+      status: "unavailable",
+    };
+    const state = reducer(initialState, { type: "metaMaskPermissionRejected" });
+    expect(initialState).toEqual(state);
+  });
+  test('change of accounts when not in statuts "connected" is not allowed', () => {
+    jest.spyOn(console, "warn").mockImplementationOnce(() => {});
+    const initialState: MetaMaskState = {
+      account: null,
+      chainId: null,
+      status: "unavailable",
+    };
+    const state = reducer(initialState, {
+      type: "metaMaskAccountsChanged",
+      payload: ["0x123"],
+    });
+    expect(initialState).toEqual(state);
+  });
+  test('change of chain ID when in statuts "initializing" is not allowed', () => {
+    jest.spyOn(console, "warn").mockImplementationOnce(() => {});
+    const initialState: MetaMaskState = {
+      account: null,
+      chainId: null,
+      status: "initializing",
+    };
+    const state = reducer(initialState, {
+      type: "metaMaskChainChanged",
+      payload: "0x1",
+    });
+    expect(initialState).toEqual(state);
+  });
+  test('change of chain ID when in statuts "unavailable" is not allowed', () => {
+    jest.spyOn(console, "warn").mockImplementationOnce(() => {});
+    const initialState: MetaMaskState = {
+      account: null,
+      chainId: null,
+      status: "unavailable",
+    };
+    const state = reducer(initialState, {
+      type: "metaMaskChainChanged",
+      payload: "0x1",
+    });
+    expect(initialState).toEqual(state);
+  });
+});

--- a/src/metamask-context.ts
+++ b/src/metamask-context.ts
@@ -1,19 +1,46 @@
 import * as React from "react";
-export interface MetaMaskState {
-  account: null | string;
-  chainId: null | string;
-  status:
-    | "initializing"
-    | "unavailable"
-    | "notConnected"
-    | "connected"
-    | "connecting";
-}
 
-export interface IMetaMaskContext extends MetaMaskState {
+type MetaMaskInitializing = {
+  account: null;
+  chainId: null;
+  status: "initializing";
+};
+
+type MetaMaskUnavailable = {
+  account: null;
+  chainId: null;
+  status: "unavailable";
+};
+
+type MetaMaskNotConnected = {
+  account: null;
+  chainId: string;
+  status: "notConnected";
+};
+
+type MetaMaskConnecting = {
+  account: null;
+  chainId: string;
+  status: "connecting";
+};
+
+type MetaMaskConnected = {
+  account: string;
+  chainId: string;
+  status: "connected";
+};
+
+export type MetaMaskState =
+  | MetaMaskInitializing
+  | MetaMaskUnavailable
+  | MetaMaskNotConnected
+  | MetaMaskConnecting
+  | MetaMaskConnected;
+
+export type IMetaMaskContext = MetaMaskState & {
   connect: () => Promise<string[] | null>;
   ethereum: any;
-}
+};
 
 export const MetamaskContext = React.createContext<
   IMetaMaskContext | undefined

--- a/src/use-metamask.ts
+++ b/src/use-metamask.ts
@@ -10,3 +10,15 @@ export function useMetaMask() {
 
   return context;
 }
+
+export function useConnectedMetaMask() {
+  const context = useMetaMask();
+
+  if (context.status !== "connected") {
+    throw new Error(
+      "`useConnectedMetaMask` can only be used when the user is connected"
+    );
+  }
+
+  return context;
+}


### PR DESCRIPTION
## Summary

The typing of the state has been improved in order to take unions of various possible state typing instead of a global typing satisfying every possibilities.

Tests have been added.

The hook `useConnectedMetaMask` has been added in order to enable type safe consuming of the state when the status is necessarily in `connected`.

Resolves #2 