### PR TITLE
feat: implement addChain and switchChain methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,66 @@ Here is an abstract on the different statuses:
 - `connected`: MetaMask is connected to the application
 - `connecting`: the connection of your accounts to the application is ongoing
 
+## Chain utils
+
+The context exposes two methods in order to facilitate the management of the networks. These methods are wrappers around the JSON RPC requests handled by MetaMask, see [MetaMask documentation](https://docs.metamask.io/guide/rpc-api.html#table-of-contents) for additonal informations.
+
+The first one is to request a switch to a different network
+```TypeScript
+function WrongNetwork() {
+  const { switchChain } = useMetaMask();
+  // Request a switch to Ethereum Mainnet
+  return (
+    <button onClick={() => switchChain("0x1")}>Switch to Ethereum Mainnet</button>
+  )
+}
+```
+
+The second one is a request to add to MetaMask a network and then connect to it
+```TypeScript
+function WrongNetwork() {
+  const { addChain } = useMetaMask();
+  const gnosisChainNetworkParams = {
+    chainId: "0x64",
+    chainName: "Gnosis Chain",
+    rpcUrls: ["https://rpc.gnosischain.com/"],
+    nativeCurrency: {
+      name: "xDAI",
+      symbol: "xDAI",
+      decimals: 18,
+    },
+    blockExplorerUrls: ["https://blockscout.com/xdai/mainnet/"]
+  };
+  // Request to add Gnosis chain and then switch to it
+  return (
+    <button onClick={() => addChain(gnosisChainNetworkParams)}>Add Gnosis chain</button>
+  )
+}
+```
+
+Finally, here is a non exhaustive list of the networks and their chain IDs
+```TypeScript
+const networks = {
+  mainnet: "0x1", // 1
+  // Test nets
+  goerli: "0x5", // 5
+  ropsten: "0x3", // 3
+  rinkeby: "0x4", // 4
+  kovan: "0x2a", // 42
+  mumbai: "0x13881", // 80001
+  // Layers 2
+  arbitrum: "0xa4b1", // 42161
+  optimism: "0xa", // 10
+  // Side chains
+  polygon: "0x89", // 137
+  gnosisChain: "0x64", // 100
+  // Alt layer 1
+  binanceSmartChain: "0x38", // 56
+  avalanche: "0xa86a", // 43114
+  cronos: "0x19", // 25
+  fantom: "0xfa" // 250
+}
+```
 ## Type safe hook
 
 Most of the time, the application will use the state when the user is connected, i.e. with status `connected`. Therefore the hook `useConnectedMetaMask` is additionally exposed, it is the same hook as `useMetaMask` but is typed with the connected state, e.g. the `account` or the `chainId` are necessarily not `null`. This hook is only usable when the status is equal to `connected`, it will throw otherwise.

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -4,6 +4,20 @@ import { setupEthTesting } from "eth-testing";
 import { useMetaMask, MetaMaskProvider } from "../";
 
 describe("MetaMask provider", () => {
+  const addChainPrams = {
+    chainId: "0x64",
+    chainName: "xDAI Chain",
+    rpcUrls: ["https://dai.poa.network"],
+    iconUrls: [
+      "https://xdaichain.com/fake/example/url/xdai.svg",
+      "https://xdaichain.com/fake/example/url/xdai.png",
+    ],
+    nativeCurrency: {
+      name: "xDAI",
+      symbol: "xDAI",
+      decimals: 18,
+    },
+  };
   const address = "0x19F7Fa0a30d5829acBD9B35bA2253a759a37EfC5";
 
   describe("when MetaMask is not available", () => {
@@ -23,6 +37,28 @@ describe("MetaMask provider", () => {
       });
 
       expect(accounts).toEqual([]);
+      expect(warn).toHaveBeenCalledTimes(1);
+    });
+
+    test("calling `addChain` should immediately return and warn the developer", async () => {
+      const warn = jest.spyOn(console, "warn").mockImplementationOnce(() => {});
+      const { result } = renderHook(useMetaMask, { wrapper: MetaMaskProvider });
+
+      await act(async () => {
+        await result.current.addChain(addChainPrams);
+      });
+
+      expect(warn).toHaveBeenCalledTimes(1);
+    });
+
+    test("calling `switchChain` should immediately return and warn the developer", async () => {
+      const warn = jest.spyOn(console, "warn").mockImplementationOnce(() => {});
+      const { result } = renderHook(useMetaMask, { wrapper: MetaMaskProvider });
+
+      await act(async () => {
+        await result.current.switchChain("0x1");
+      });
+
       expect(warn).toHaveBeenCalledTimes(1);
     });
   });
@@ -65,6 +101,162 @@ describe("MetaMask provider", () => {
       });
 
       expect(result.current.chainId).toEqual(otherChainId);
+    });
+
+    describe("chain utils", () => {
+      beforeEach(() => {
+        testingUtils.mockAccounts([]);
+        testingUtils.mockChainId("0x1");
+      });
+
+      test("calling `addChain` should trigger the expected RPC request", async () => {
+        testingUtils.lowLevel.mockRequest("wallet_addEthereumChain", undefined);
+
+        const { result, waitForNextUpdate } = renderHook(useMetaMask, {
+          wrapper: MetaMaskProvider,
+        });
+
+        expect(result.current.status).toEqual("initializing");
+
+        await waitForNextUpdate();
+
+        expect(result.current.status).toEqual("notConnected");
+
+        await act(async () => {
+          return result.current.addChain(addChainPrams).then(() => {
+            testingUtils.mockChainChanged(addChainPrams.chainId);
+          });
+        });
+
+        expect(result.current.chainId).toEqual(addChainPrams.chainId);
+      });
+
+      test("calling `addChain` when a current request is pending should return", async () => {
+        const error = {
+          code: -32002,
+        };
+        testingUtils.lowLevel.mockRequest("wallet_addEthereumChain", error, {
+          shouldThrow: true,
+        });
+
+        const { result, waitForNextUpdate } = renderHook(useMetaMask, {
+          wrapper: MetaMaskProvider,
+        });
+
+        expect(result.current.status).toEqual("initializing");
+
+        await waitForNextUpdate();
+
+        expect(result.current.status).toEqual("notConnected");
+
+        await act(async () => {
+          return result.current.addChain(addChainPrams).then(() => {
+            testingUtils.mockChainChanged(addChainPrams.chainId);
+          });
+        });
+
+        expect(result.current.chainId).toEqual(addChainPrams.chainId);
+      });
+
+      test("calling `addChain` should throw if the underlying request throws with a unhandled code", async () => {
+        const error = {
+          code: -32003,
+        };
+        testingUtils.lowLevel.mockRequest("wallet_addEthereumChain", error, {
+          shouldThrow: true,
+        });
+
+        const { result, waitForNextUpdate } = renderHook(useMetaMask, {
+          wrapper: MetaMaskProvider,
+        });
+
+        expect(result.current.status).toEqual("initializing");
+
+        await waitForNextUpdate();
+
+        expect(result.current.status).toEqual("notConnected");
+
+        await expect(() =>
+          result.current.addChain(addChainPrams)
+        ).rejects.toEqual(error);
+      });
+
+      test("calling `switchChain` should trigger the expected RPC request", async () => {
+        const newChainId = "0x2";
+        testingUtils.lowLevel.mockRequest(
+          "wallet_switchEthereumChain",
+          undefined
+        );
+
+        const { result, waitForNextUpdate } = renderHook(useMetaMask, {
+          wrapper: MetaMaskProvider,
+        });
+
+        expect(result.current.status).toEqual("initializing");
+
+        await waitForNextUpdate();
+
+        expect(result.current.status).toEqual("notConnected");
+
+        await act(async () => {
+          return result.current.switchChain(newChainId).then(() => {
+            testingUtils.mockChainChanged(newChainId);
+          });
+        });
+
+        expect(result.current.chainId).toEqual(newChainId);
+      });
+
+      test("calling `switchChain` when a current request is pending should return", async () => {
+        const newChainId = "0x2";
+        const error = {
+          code: -32002,
+        };
+        testingUtils.lowLevel.mockRequest("wallet_switchEthereumChain", error, {
+          shouldThrow: true,
+        });
+
+        const { result, waitForNextUpdate } = renderHook(useMetaMask, {
+          wrapper: MetaMaskProvider,
+        });
+
+        expect(result.current.status).toEqual("initializing");
+
+        await waitForNextUpdate();
+
+        expect(result.current.status).toEqual("notConnected");
+
+        await act(async () => {
+          return result.current.switchChain(newChainId).then(() => {
+            testingUtils.mockChainChanged(newChainId);
+          });
+        });
+
+        expect(result.current.chainId).toEqual(newChainId);
+      });
+
+      test("calling `switchChain` should throw if the underlying request throws with a unhandled code", async () => {
+        const error = {
+          code: -32003,
+        };
+        testingUtils.lowLevel.mockRequest("wallet_switchEthereumChain", error, {
+          shouldThrow: true,
+        });
+
+        const { result, waitForNextUpdate } = renderHook(useMetaMask, {
+          wrapper: MetaMaskProvider,
+        });
+
+        expect(result.current.status).toEqual("initializing");
+
+        await waitForNextUpdate();
+
+        expect(result.current.status).toEqual("notConnected");
+
+        await expect(() => result.current.switchChain("0x2")).rejects.toEqual(
+          error
+        );
+      });
     });
 
     describe("when MetaMask is not connected", () => {

--- a/src/metamask-context.ts
+++ b/src/metamask-context.ts
@@ -1,5 +1,18 @@
 import * as React from "react";
 
+export type AddEthereumChainParameter = {
+  chainId: string;
+  blockExplorerUrls?: string[];
+  chainName?: string;
+  iconUrls?: string[];
+  nativeCurrency?: {
+    name: string;
+    symbol: string;
+    decimals: number;
+  };
+  rpcUrls?: string[];
+};
+
 type MetaMaskInitializing = {
   account: null;
   chainId: null;
@@ -38,7 +51,25 @@ export type MetaMaskState =
   | MetaMaskConnected;
 
 export type IMetaMaskContext = MetaMaskState & {
+  /**
+   * Connect the application to MetaMask
+   * @returns Array of connected accounts when connection is successful, `null` if method not ready to be used
+   */
   connect: () => Promise<string[] | null>;
+  /**
+   * Request addition of a new network
+   * @param parameters New chain parameters, see [EIP-3085](https://eips.ethereum.org/EIPS/eip-3085) for full description
+   */
+  addChain: (parameters: AddEthereumChainParameter) => Promise<void>;
+  /**
+   * Request a switch of network
+   * @param chainId Chain ID of the network in hexadecimal
+   * @example ```ts
+   * // Switch chain to Ethereum Mainnet
+   * await context.switchChain("0x1");
+   * ```
+   */
+  switchChain: (chainId: string) => Promise<void>;
   ethereum: any;
 };
 

--- a/src/metamask-provider.tsx
+++ b/src/metamask-provider.tsx
@@ -120,18 +120,32 @@ function requestAccounts(
 
 async function addEthereumChain(parameters: AddEthereumChainParameter) {
   const ethereum = (window as WindowInstanceWithEthereum).ethereum;
-  await ethereum.request({
-    method: "wallet_addEthereumChain",
-    params: [parameters],
-  });
+  try {
+    await ethereum.request({
+      method: "wallet_addEthereumChain",
+      params: [parameters],
+    });
+  } catch (err: unknown) {
+    if ("code" in (err as { [key: string]: any })) {
+      if ((err as ErrorWithCode).code === ERROR_CODE_REQUEST_PENDING) return;
+    }
+    throw err;
+  }
 }
 
 async function switchEthereumChain(chainId: string) {
   const ethereum = (window as WindowInstanceWithEthereum).ethereum;
-  await ethereum.request({
-    method: "wallet_switchEthereumChain",
-    params: [{ chainId }],
-  });
+  try {
+    await ethereum.request({
+      method: "wallet_switchEthereumChain",
+      params: [{ chainId }],
+    });
+  } catch (err: unknown) {
+    if ("code" in (err as { [key: string]: any })) {
+      if ((err as ErrorWithCode).code === ERROR_CODE_REQUEST_PENDING) return;
+    }
+    throw err;
+  }
 }
 
 const initialState: MetaMaskState = {


### PR DESCRIPTION
## Summary

Add `addChain` and `switchChain` methods as network utils. These methods are wrappers `wallet_addEthereumChain` and `wallet_switchEthereumChain` RPC methods, see [MetaMask documentation](https://docs.metamask.io/guide/rpc-api.html#table-of-contents) for additional informations.

Tests have been updated.

The README has been updated with the two methods and a non exhaustive list of the networks.

Resolves #23 